### PR TITLE
Some very minor markdown cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A mod loader for [Neos VR](https://neos.com/). Consider joining our community on
 If you are using the Steam version of Neos you are in the right place. If you are using the standalone version, read the [Neos Standalone Setup](doc/neos_standalone_setup.md) instructions. If you are on Linux, read the [Linux Notes](doc/linux.md).
 
 1. Download [NeosModLoader.dll](https://github.com/neos-modding-group/NeosModLoader/releases/latest/download/NeosModLoader.dll) to Neos's `Libraries` folder (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Libraries`).
-2. Place [0Harmony.dll](https://github.com/neos-modding-group/NeosModLoader/releases/download/1.4.1/0Harmony.dll) in your Neos install directory (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR`).
+2. Place [0Harmony.dll](https://github.com/neos-modding-group/NeosModLoader/releases/download/1.9.1/0Harmony.dll) in your Neos install directory (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR`).
 3. Add mod DLL files to a `nml_mods` folder under your Neos install directory (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\nml_mods`). You can create the folder if it's missing, or simply launch Neos once with NeosModLoader installed and it will be created automatically.
 4. Add the following to Neos's [launch options](https://wiki.neos.com/Command_Line_Arguments): `-LoadAssembly Libraries\NeosModLoader.dll`, substituting the path for wherever you put `NeosModLoader.dll`.
 5. Start the game. If you want to verify that NeosModLoader is working you can check the Neos logs. (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Logs`). The modloader adds some very obvious logs on startup, and if they're missing something has gone wrong. Here is an [example log file](doc/example_log.log) where everything worked correctly.
@@ -43,7 +43,7 @@ Note that the libraries can also be in the root of the Neos install directory if
 
 ## Finding Mods
 
-A list of known mods is available in the [Neos Mod List](https://github.com/zkxs/neos-mod-list/blob/master/README.md). New mods and updates are also announced in [our Discord][Neos Modding Discord].
+A list of known mods is available in the [Neos Mod List](https://github.com/neos-modding-group/neos-mod-manifest/blob/master/README.md#mods). New mods and updates are also announced in [our Discord][Neos Modding Discord].
 
 ## Frequently Asked Questions
 
@@ -67,13 +67,13 @@ NeosModLoader is licensed under the GNU Lesser General Public License (LGPL). Se
 
 Third-party libraries distributed alongside NeosModLoader:
 
-- [LibHarmony] ([MIT License](https://github.com/pardeike/Harmony/blob/79d62b42c71d005b3cb1d94e741bfd4ce7e03a6b/LICENSE))
+- [LibHarmony] ([MIT License](https://github.com/pardeike/Harmony/blob/master/LICENSE))
 
 Third-party libraries used in source:
 
 - [.NET](https://github.com/dotnet) (Various licenses)
 - [Neos VR](https://neos.com/) ([EULA](https://store.steampowered.com//eula/740250_eula_0))
-- [Json.NET](https://github.com/JamesNK/Newtonsoft.Json) ([MIT License](https://github.com/JamesNK/Newtonsoft.Json/blob/52190a3a3de6ef9a556583cbcb2381073e7197bc/LICENSE.md))
+- [Json.NET](https://github.com/JamesNK/Newtonsoft.Json) ([MIT License](https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md))
 
 <!--- Link References -->
 [LibHarmony]: https://github.com/pardeike/Harmony

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ NeosModLoader is licensed under the GNU Lesser General Public License (LGPL). Se
 
 Third-party libraries distributed alongside NeosModLoader:
 
-- [LibHarmony] ([MIT License](https://github.com/pardeike/Harmony/blob/master/LICENSE))
+- [LibHarmony] ([MIT License](https://github.com/pardeike/Harmony/blob/v2.2.1.0/LICENSE))
 
 Third-party libraries used in source:
 

--- a/doc/linux.md
+++ b/doc/linux.md
@@ -1,6 +1,6 @@
 # Linux Notes
 
-NeosModLoader works on Linux, but in addtion to the [normal install steps](../README.md#installation) there are some extra steps you need to take until Neos issue [#2638](https://github.com/Neos-Metaverse/NeosPublic/issues/2638) is fixed.
+NeosModLoader works on Linux, but in addition to the [normal install steps](../README.md#installation) there are some extra steps you need to take until Neos issue [#2638](https://github.com/Neos-Metaverse/NeosPublic/issues/2638) is fixed.
 
 The log directory on Linux is `$HOME/.local/share/Steam/steamapps/common/NeosVR/Logs`
 

--- a/doc/modloader_config.md
+++ b/doc/modloader_config.md
@@ -13,8 +13,8 @@ Not all keys are required to be present. Missing keys will use the defaults outl
 | ------------------ | ------- | ----------- |
 | `debug`            | `false` | If `true`, NeosMod.Debug() logs will appear in your log file. Otherwise, they are hidden. |
 | `hidevisuals`      | `false` | If `true`, NML won't show any visual indication of being installed, such as a loading indicator on the splash screen. |
-| `nomods`           | `false` | If `true`, mods will not be loaded. |
-| `nolibraries`      | `false` | If `true`, extra libraries will not be loaded. |
+| `nomods`           | `false` | If `true`, mods will not be loaded from `nml_mods`. |
+| `nolibraries`      | `false` | If `true`, extra libraries from `nml_libs` will not be loaded. |
 | `advertiseversion` | `false` | If `false`, your version will be spoofed and will resemble `2021.8.29.1240`. If `true`, your version will be left unaltered and will resemble `2021.8.29.1240+NeosModLoader.dll`. This version string is visible to other players under certain circumstances. |
 | `unsafe`           | `false` | If `true`, the version spoofing safety check is disabled and it will still work even if you have other Neos plugins. DO NOT load plugin components in multiplayer sessions, as it will break things and cause crashes. Plugin components should only be used in your local home or user space. |
 | `logconflicts`     | `true`  | If `false`, conflict logging will be disabled. If `true`, potential mod conflicts will be logged. If `debug` is also `true` this will be more verbose. |


### PR DESCRIPTION
Changes the Harmony link to a more up to date one, the license links to just the master branch ones instead of specific ones, and also additionally makes some docs slightly clearer.