### PR TITLE
Add csproj for Headless

### DIFF
--- a/NeosModLoader.sln
+++ b/NeosModLoader.sln
@@ -4,6 +4,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.31410.357
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NeosModLoader", "NeosModLoader\NeosModLoader.csproj", "{D4627C7F-8091-477A-ABDC-F1465D94D8D9}"
+Project("{3f7663fa-1fa3-408d-9ccb-26b80dae218c}") = "NeosModLoader", "NeosModLoader\NeosModLoaderHeadless.csproj", "{4a54bcdf-0386-43fc-9aa5-d49ce7d33dd8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +16,10 @@ Global
 		{D4627C7F-8091-477A-ABDC-F1465D94D8D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4627C7F-8091-477A-ABDC-F1465D94D8D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4627C7F-8091-477A-ABDC-F1465D94D8D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4a54bcdf-0386-43fc-9aa5-d49ce7d33dd8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4a54bcdf-0386-43fc-9aa5-d49ce7d33dd8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4a54bcdf-0386-43fc-9aa5-d49ce7d33dd8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4a54bcdf-0386-43fc-9aa5-d49ce7d33dd8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NeosModLoader/NeosModLoaderHeadless.csproj
+++ b/NeosModLoader/NeosModLoaderHeadless.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{4a54bcdf-0386-43fc-9aa5-d49ce7d33dd8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NeosModLoader</RootNamespace>
+    <AssemblyTitle>NeosModLoader</AssemblyTitle>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo> 
+    <TargetFramework>net462</TargetFramework>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NeosPath>$(MSBuildThisFileDirectory)NeosVR</NeosPath>
+    <NeosPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\NeosVR\')">C:\Program Files (x86)\Steam\steamapps\common\NeosVR\</NeosPath>
+    <NeosPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/NeosVR/')">$(HOME)/.steam/steam/steamapps/common/NeosVR/</NeosPath>
+    <CopyToPlugins Condition="'$(CopyToPlugins)'==''">true</CopyToPlugins>
+    <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>
+    <DebugType Condition="'$(Configuration)'=='Release'">None</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lib.Harmony" Version="2.2.0" />
+    <Reference Include="BaseX">
+      <HintPath>$(NeosPath)HeadlessClient\BaseX.dll</HintPath>
+    </Reference>
+    <Reference Include="FrooxEngine">
+      <HintPath>$(NeosPath)HeadlessClient\FrooxEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(NeosPath)HeadlessClient\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToPlugins)'=='true'">
+      <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(NeosPath)HeadlessClient\Libraries" />
+  </Target>
+</Project>


### PR DESCRIPTION
just add csproj for Headless client, this can be launch directly, but some mods may not be load well just now, so plz more fix or push both branch dll if this solution uses.

```
[INFO] [NeosModLoader] D:\***\HeadlessClient\NeosModLoader.config is missing! This is probably fine.
[INFO] [NeosModLoader] NeosModLoader v1.8.0 starting up!
[INFO] [NeosModLoader] Using Harmony v2.2.1.0
[INFO] [NeosModLoader] Using BaseX v1.0.0.0
[INFO] [NeosModLoader] Using FrooxEngine v2022.1.28.1335
[INFO] [NeosModLoader] Using Json.NET v13.0.0.0
[INFO] [NeosModLoader] Compatibility hash spoofing succeeded
[ERROR][NeosModLoader] Unexpected exception initializing mod from D:\***\Modding\HeadlessClient\nml_mods\KillLogSpam.dll:
System.Reflection.ReflectionTypeLoadException: 要求された型のうち 1 つまたは複数を読み込めませんでした。詳細については、LoaderExceptions プロパティを 取得してください。
   場所 System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   場所 System.Reflection.Assembly.GetTypes()
   場所 NeosModLoader.ModLoader.InitializeMod(ModAssembly mod)
   場所 NeosModLoader.ModLoader.LoadMods()
```