### PR TITLE
Additional logging for ReflectionTypeLoadException

### DIFF
--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace NeosModLoader
 {
@@ -64,6 +65,25 @@ namespace NeosModLoader
                         // if loading succeeded, then we need to register the mod
                         RegisterMod(loaded);
                     }
+                }
+                catch (ReflectionTypeLoadException reflectionTypeLoadException)
+                {
+                    // this exception type has some inner exceptions we must also log to gain any insight into what went wrong
+                    StringBuilder sb = new();
+                    sb.AppendLine(reflectionTypeLoadException.ToString());
+                    foreach (Exception loaderException in reflectionTypeLoadException.LoaderExceptions)
+                    {
+                        sb.AppendLine($"Loader Exception: {loaderException.Message}");
+                        if (loaderException is FileNotFoundException fileNotFoundException)
+                        {
+                            if (!string.IsNullOrEmpty(fileNotFoundException.FusionLog))
+                            {
+                                sb.Append("    Fusion Log:\n    ");
+                                sb.AppendLine(fileNotFoundException.FusionLog);
+                            }
+                        }
+                    }
+                    Logger.ErrorInternal($"ReflectionTypeLoadException initializing mod from {mod.File}:\n{sb}");
                 }
                 catch (Exception e)
                 {

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -10,7 +10,7 @@ namespace NeosModLoader
 {
     public class ModLoader
     {
-        internal const string VERSION_CONSTANT = "1.11.0";
+        internal const string VERSION_CONSTANT = "1.11.1";
         /// <summary>
         /// NeosModLoader's version
         /// </summary>

--- a/NeosModLoader/Utility/EnumerableInjector.cs
+++ b/NeosModLoader/Utility/EnumerableInjector.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NeosModLoader.Utility
 {


### PR DESCRIPTION
This is to help troubleshoot mod loading issues such as [this](https://discord.com/channels/901126079857692714/901129369832026213/992713735514882089).

Relevant log snippet:
```
8:42:44 pm.573	[ERROR][NeosModLoader] Unexpected exception initializing mod from C:\Program Files (x86)\Steam\steamapps\common\NeosVR\HeadlessClient\nml_mods\HeadlessTweaks.dll:
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.Assembly.GetTypes()
   at NeosModLoader.ModLoader.InitializeMod(AssemblyFile mod)
   at NeosModLoader.ModLoader.LoadMods()
```

I'm actually very mad that Microsoft just logs in their Exception.ToString() that they were too lazy to implement a proper ToString() and it's somehow my job.

---

Also, the VS code cleanup disliked some imports in EnumerableInjector.