### PR TITLE
Unbork AssemblyName on headless build

### DIFF
--- a/NeosModLoader/ExecutionHook.cs
+++ b/NeosModLoader/ExecutionHook.cs
@@ -1,5 +1,6 @@
 using FrooxEngine;
 using System;
+using System.Linq;
 
 namespace NeosModLoader
 {
@@ -17,7 +18,13 @@ namespace NeosModLoader
             try
             {
                 SplashChanger.SetCustom("Loading libraries");
-                AssemblyLoader.LoadAssembliesFromDir("nml_libs");
+                AssemblyFile[] loadedAssemblies = AssemblyLoader.LoadAssembliesFromDir("nml_libs");
+                if (loadedAssemblies.Length != 0)
+                {
+                    string loadedAssemblyList = string.Join("\n", loadedAssemblies.Select(a => a.Assembly.FullName));
+                    Logger.MsgInternal($"Loaded libraries from nml_libs:\n{loadedAssemblyList}");
+                }
+
                 SplashChanger.SetCustom("Initializing");
                 DebugInfo.Log();
                 NeosVersionReset.Initialize();

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -10,7 +10,7 @@ namespace NeosModLoader
 {
     public class ModLoader
     {
-        internal const string VERSION_CONSTANT = "1.11.1";
+        internal const string VERSION_CONSTANT = "1.11.2";
         /// <summary>
         /// NeosModLoader's version
         /// </summary>

--- a/NeosModLoader/NeosModLoader.csproj
+++ b/NeosModLoader/NeosModLoader.csproj
@@ -6,17 +6,17 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NeosModLoader</RootNamespace>
     <Headless Condition="'$(Headless)'!='true'">false</Headless>
-    <AssemblyName Condition="'$(Headless)'=='false'">NeosModLoader</AssemblyName>
-    <AssemblyName Condition="'$(Headless)'=='true'">NeosModLoaderHeadless</AssemblyName>
-    <AssemblyTitle>$(AssemblyName)</AssemblyTitle>
+    <AssemblyName>NeosModLoader</AssemblyName>
+    <AssemblyTitle Condition="'$(Headless)'=='false'">NeosModLoader</AssemblyTitle>
+    <AssemblyTitle Condition="'$(Headless)'=='true'">NeosModLoaderHeadless</AssemblyTitle>
+    <AssemblyFileName>$(AssemblyTitle).dll</AssemblyFileName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
-    <CopyToLibraries Condition="'$(CopyToLibraries)'=='' And '$(Headless)'=='false'">true</CopyToLibraries>
-    <CopyToLibraries Condition="'$(CopyToLibraries)'=='' And '$(Headless)'=='true'">false</CopyToLibraries>
+    <CopyToLibraries Condition="'$(CopyToLibraries)'==''">true</CopyToLibraries>
     <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>
     <DebugType Condition="'$(Configuration)'=='Release'">None</DebugType>
   </PropertyGroup>
@@ -42,8 +42,8 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToLibraries)'=='true'">
-    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(NeosPath)Libraries" />
-    <Message Text="Copied $(TargetFileName) to $(NeosPath)Libraries" Importance="high" />
+    <Copy SourceFiles="$(TargetDir)$(TargetFileName)" DestinationFiles="$(NeosPath)Libraries\$(AssemblyFileName)" />
+    <Message Text="Copied $(TargetFileName) to $(NeosPath)Libraries\$(AssemblyFileName)" Importance="high" />
   </Target>
 
 </Project>


### PR DESCRIPTION
1. AssemblyName is now ALWAYS NeosModLoader, because apparently Windows requires this?
2. Adds some extra logging for what nml_libs get loaded