### PR TITLE
clearify hidevisuals config option

### DIFF
--- a/doc/modloader_config.md
+++ b/doc/modloader_config.md
@@ -12,7 +12,7 @@ Not all keys are required to be present. Missing keys will use the defaults outl
 | Configuration      | Default | Description |
 | ------------------ | ------- | ----------- |
 | `debug`            | `false` | If `true`, NeosMod.Debug() logs will appear in your log file. Otherwise, they are hidden. |
-| `hidevisuals`      | `false` | If `true`, NML won't show any visual indication of being installed, such as a loading indicator on the splash screen. |
+| `hidevisuals`      | `false` | If `true`, NML won't show a loading indicator on the splash screen. |
 | `nomods`           | `false` | If `true`, mods will not be loaded from `nml_mods`. |
 | `nolibraries`      | `false` | If `true`, extra libraries from `nml_libs` will not be loaded. |
 | `advertiseversion` | `false` | If `false`, your version will be spoofed and will resemble `2021.8.29.1240`. If `true`, your version will be left unaltered and will resemble `2021.8.29.1240+NeosModLoader.dll`. This version string is visible to other players under certain circumstances. |


### PR DESCRIPTION
the current description could confuse users into thinking that this config option would also hide any mode created visuals. if nml ever gets anymore direct visuals (unlikely) we can update the docs.