### PR TITLE
Prevent PostX processing of the NML assembly

### DIFF
--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -10,7 +10,7 @@ namespace NeosModLoader
 {
     public class ModLoader
     {
-        internal const string VERSION_CONSTANT = "1.11.2";
+        internal const string VERSION_CONSTANT = "1.11.3";
         /// <summary>
         /// NeosModLoader's version
         /// </summary>

--- a/NeosModLoader/Properties/AssemblyInfo.cs
+++ b/NeosModLoader/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -33,3 +34,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion(NeosModLoader.ModLoader.VERSION_CONSTANT)]
 [assembly: AssemblyFileVersion(NeosModLoader.ModLoader.VERSION_CONSTANT)]
+
+// prevent PostX from modifying my assembly, as it doesn't need anything done to it
+// this keeps PostX from overwriting my AssemblyVersionAttribute
+[module: Description("POSTX_PROCESSED")]


### PR DESCRIPTION
1. PostX does nothing beneficial to NML, and is not needed
2. PostX changes NML's hash, which could be potentially problematic
   - If we ever sign the DLL
   - If the mod manager verifies files
3. PostX changes NML's AssemblyVersionAttribute, which can lead to extremely confusing logs

Specifically, logs like this are confusing because there is no such thing as NML version 2022.4.24.539
```
Loader Exception: Could not load file or assembly 'NeosModLoader, Version=2022.4.24.539, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.
```