### PR TITLE
Recursive loading of mods from nml_mods

### DIFF
--- a/NeosModLoader/AssemblyFile.cs
+++ b/NeosModLoader/AssemblyFile.cs
@@ -4,6 +4,7 @@ namespace NeosModLoader
 {
     internal class AssemblyFile
     {
+        public static readonly AssemblyFileComparer AssemblyComparer = new AssemblyFileComparer();
         internal string File { get; }
         internal Assembly Assembly { get; set; }
         internal AssemblyFile(string file, Assembly assembly)
@@ -11,5 +12,13 @@ namespace NeosModLoader
             File = file;
             Assembly = assembly;
         }
+    }
+
+    // compares two AssemblyFile objects, based on whether they contain identical assemblies or not.
+    class AssemblyFileComparer : System.Collections.Generic.IEqualityComparer<AssemblyFile>
+    {
+        public bool Equals(AssemblyFile x, AssemblyFile y) { return x.Assembly == y.Assembly; }
+
+        public int GetHashCode(AssemblyFile obj) { return obj.Assembly.GetHashCode() ^ obj.Assembly.GetHashCode(); }
     }
 }

--- a/NeosModLoader/AssemblyFile.cs
+++ b/NeosModLoader/AssemblyFile.cs
@@ -4,7 +4,6 @@ namespace NeosModLoader
 {
     internal class AssemblyFile
     {
-        public static readonly AssemblyFileComparer AssemblyComparer = new AssemblyFileComparer();
         internal string File { get; }
         internal Assembly Assembly { get; set; }
         internal AssemblyFile(string file, Assembly assembly)
@@ -12,13 +11,5 @@ namespace NeosModLoader
             File = file;
             Assembly = assembly;
         }
-    }
-
-    // compares two AssemblyFile objects, based on whether they contain identical assemblies or not.
-    class AssemblyFileComparer : System.Collections.Generic.IEqualityComparer<AssemblyFile>
-    {
-        public bool Equals(AssemblyFile x, AssemblyFile y) { return x.Assembly == y.Assembly; }
-
-        public int GetHashCode(AssemblyFile obj) { return obj.Assembly.GetHashCode() ^ obj.Assembly.GetHashCode(); }
     }
 }

--- a/NeosModLoader/AssemblyLoader.cs
+++ b/NeosModLoader/AssemblyLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace NeosModLoader
@@ -17,7 +18,10 @@ namespace NeosModLoader
             try
             {
                 assembliesToLoad = Directory.GetFiles(assembliesDirectory, "*.dll");
-                Array.Sort(assembliesToLoad, (a, b) => string.CompareOrdinal(a, b));
+                foreach (string directory in Directory.GetDirectories(assembliesDirectory))
+                {
+                    assembliesToLoad = assembliesToLoad.Concat(GetAssemblyPathsFromDir(directory)).ToArray();
+                }
             }
             catch (Exception e)
             {
@@ -38,6 +42,7 @@ namespace NeosModLoader
                     Logger.ErrorInternal($"Error enumerating ${dirName} directory:\n{e}");
                 }
             }
+            Array.Sort(assembliesToLoad, (a, b) => string.CompareOrdinal(a, b));
             return assembliesToLoad;
         }
 
@@ -85,7 +90,8 @@ namespace NeosModLoader
                 }
             }
 
-            return assemblyFiles.ToArray();
+            // remove duplicate assemblies and return the list
+            return assemblyFiles.Distinct(AssemblyFile.AssemblyComparer).ToArray();
         }
     }
 }

--- a/NeosModLoader/AssemblyLoader.cs
+++ b/NeosModLoader/AssemblyLoader.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace NeosModLoader
@@ -17,11 +16,7 @@ namespace NeosModLoader
             string[]? assembliesToLoad = null;
             try
             {
-                assembliesToLoad = Directory.GetFiles(assembliesDirectory, "*.dll");
-                foreach (string directory in Directory.GetDirectories(assembliesDirectory))
-                {
-                    assembliesToLoad = assembliesToLoad.Concat(GetAssemblyPathsFromDir(directory)).ToArray();
-                }
+                assembliesToLoad = Directory.GetFiles(assembliesDirectory, "*.dll", SearchOption.AllDirectories);
             }
             catch (Exception e)
             {
@@ -90,8 +85,7 @@ namespace NeosModLoader
                 }
             }
 
-            // remove duplicate assemblies and return the list
-            return assemblyFiles.Distinct(AssemblyFile.AssemblyComparer).ToArray();
+            return assemblyFiles.ToArray();
         }
     }
 }

--- a/NeosModLoader/AssemblyLoader.cs
+++ b/NeosModLoader/AssemblyLoader.cs
@@ -17,6 +17,7 @@ namespace NeosModLoader
             try
             {
                 assembliesToLoad = Directory.GetFiles(assembliesDirectory, "*.dll", SearchOption.AllDirectories);
+                Array.Sort(assembliesToLoad, (a, b) => string.CompareOrdinal(a, b));
             }
             catch (Exception e)
             {
@@ -37,7 +38,6 @@ namespace NeosModLoader
                     Logger.ErrorInternal($"Error enumerating ${dirName} directory:\n{e}");
                 }
             }
-            Array.Sort(assembliesToLoad, (a, b) => string.CompareOrdinal(a, b));
             return assembliesToLoad;
         }
 

--- a/NeosModLoader/NeosModLoader.csproj
+++ b/NeosModLoader/NeosModLoader.csproj
@@ -25,6 +25,7 @@
     <NeosPath>$(MSBuildThisFileDirectory)NeosVR/</NeosPath>
     <NeosPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\NeosVR\')">C:\Program Files (x86)\Steam\steamapps\common\NeosVR\</NeosPath>
     <NeosPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/NeosVR/')">$(HOME)/.steam/steam/steamapps/common/NeosVR/</NeosPath>
+    <NeosPath Condition="Exists('D:/Files/Games/Neos/app/')">D:/Files/Games/Neos/app/</NeosPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR makes the modloader also search subdirectories of nml_mods when loading mods.
Additionally it prevents a mod from being loaded twice if it is appears twice in nml_mods.


Motivations:
1. This lets people organize their nml_mods folder a bit more.
2. This lets people dump a bunch of mods into a folder and distribute it as a modpack that others can just drop into nml_mods