### PR TITLE
Added late loading functionality for mods.

### DIFF
--- a/NeosModLoader/AssemblyLoader.cs
+++ b/NeosModLoader/AssemblyLoader.cs
@@ -64,6 +64,22 @@ namespace NeosModLoader
             return assembly;
         }
 
+        internal static AssemblyFile? LoadAssemblyFile(string filepath)
+        {
+            try
+            {
+                if (LoadAssembly(filepath) is Assembly assembly)
+                {
+                    return new AssemblyFile(filepath, assembly);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.ErrorInternal($"Unexpected exception loading assembly from {filepath}:\n{e}");
+            }
+            return null;
+        }
+
         internal static AssemblyFile[] LoadAssembliesFromDir(string dirName)
         {
             List<AssemblyFile> assemblyFiles = new();
@@ -71,16 +87,10 @@ namespace NeosModLoader
             {
                 foreach (string assemblyFilepath in assemblyPaths)
                 {
-                    try
+                    AssemblyFile? loadedAssemblyFile = LoadAssemblyFile(assemblyFilepath);
+                    if (loadedAssemblyFile != null)
                     {
-                        if (LoadAssembly(assemblyFilepath) is Assembly assembly)
-                        {
-                            assemblyFiles.Add(new AssemblyFile(assemblyFilepath, assembly));
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.ErrorInternal($"Unexpected exception loading assembly from {assemblyFilepath}:\n{e}");
+                        assemblyFiles.Add(loadedAssemblyFile);
                     }
                 }
             }

--- a/NeosModLoader/ExecutionHook.cs
+++ b/NeosModLoader/ExecutionHook.cs
@@ -28,6 +28,7 @@ namespace NeosModLoader
                 SplashChanger.SetCustom("Initializing");
                 DebugInfo.Log();
                 NeosVersionReset.Initialize();
+                ModLoader.WatchModsDirectory();
                 ModLoader.LoadMods();
                 SplashChanger.SetCustom("Loaded");
             }

--- a/NeosModLoader/NeosMod.cs
+++ b/NeosModLoader/NeosMod.cs
@@ -30,6 +30,15 @@ namespace NeosModLoader
         public virtual void OnEngineInit() { }
 
         /// <summary>
+        /// Called once when the mod is loaded at runtime and calls OnEngineInit() for backwards compatibility.
+        /// Can be overriden by a mod to achieve custom behavior.
+        /// </summary>
+        public void OnLateInit()
+        {
+            OnEngineInit();
+        }
+
+        /// <summary>
         /// Build the defined configuration for this mod.
         /// </summary>
         /// <returns>This mod's configuration definition.</returns>


### PR DESCRIPTION
This makes the modloader watch the nml_mods directory and attempt to load any new .dll file it finds in there during runtime as a new mod.

This also adds a new function, OnLateInit() to the NeosMod class. This can be overriden by a mod to handle late loading differently from being loaded at startup.

When late loading a mod, the modloader will use the FrooxEngine.LoadingIndicator to indicate success or failure to the user so that a new mod appearing isn't entirely invisible.

Multiple sections of code in the ModLoader and one in AssemblyLoader have been turned into their own functions to be reused during late loading.