### PR TITLE
Fix compatibility hash spoofing when plugins are present.

### DIFF
--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -10,7 +10,7 @@ namespace NeosModLoader
 {
   public class ModLoader
   {
-    internal const string VERSION_CONSTANT = "1.11.3";
+    internal const string VERSION_CONSTANT = "1.12.0";
     /// <summary>
     /// NeosModLoader's version
     /// </summary>

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -8,17 +8,17 @@ using System.Text;
 
 namespace NeosModLoader
 {
-  public class ModLoader
-  {
-    internal const string VERSION_CONSTANT = "1.12.0";
-    /// <summary>
-    /// NeosModLoader's version
-    /// </summary>
-    public static readonly string VERSION = VERSION_CONSTANT;
-    private static readonly Type NEOS_MOD_TYPE = typeof(NeosMod);
-    private static readonly List<LoadedNeosMod> LoadedMods = new(); // used for mod enumeration
-    internal static readonly Dictionary<Assembly, NeosMod> AssemblyLookupMap = new(); // used for logging
-    private static readonly Dictionary<string, LoadedNeosMod> ModNameLookupMap = new(); // used for duplicate mod checking
+	public class ModLoader
+	{
+		internal const string VERSION_CONSTANT = "1.12.0";
+		/// <summary>
+		/// NeosModLoader's version
+		/// </summary>
+		public static readonly string VERSION = VERSION_CONSTANT;
+		private static readonly Type NEOS_MOD_TYPE = typeof(NeosMod);
+		private static readonly List<LoadedNeosMod> LoadedMods = new(); // used for mod enumeration
+		internal static readonly Dictionary<Assembly, NeosMod> AssemblyLookupMap = new(); // used for logging
+		private static readonly Dictionary<string, LoadedNeosMod> ModNameLookupMap = new(); // used for duplicate mod checking
 
 		/// <summary>
 		/// Allows reading metadata for all loaded mods

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -85,10 +85,10 @@ namespace NeosModLoader
 			return BitConverter.ToString(hash).Replace("-", "");
 		}
 
-    internal static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T>? comparer = null)
-    {
-      return new HashSet<T>(source, comparer);
-    }
+		internal static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T>? comparer = null)
+		{
+			return new HashSet<T>(source, comparer);
+		}
 
-  }
+	}
 }

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -1,10 +1,11 @@
 using System;
-using System.IO;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Security.Cryptography;
 
 namespace NeosModLoader
 {
@@ -82,6 +83,11 @@ namespace NeosModLoader
       using var stream = File.OpenRead(filepath);
       var hash = hasher.ComputeHash(stream);
       return BitConverter.ToString(hash).Replace("-", "");
+    }
+
+    internal static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T>? comparer = null)
+    {
+      return new HashSet<T>(source, comparer);
     }
 
   }


### PR DESCRIPTION
Resolves #58.

This enumerates all loaded assemblies and uses a couple of heuristics to make a *very* educated guess about which ones are plugins. Those plugins are then used in the compatibility hash calculation.

---

edit: I'll go into more detail

1. Enumerate all loaded assemblies using Froox's own `[module: Description("POSTX_PROCESSED")]` marker to filter to just the PostX processed assemblies
2. Attempt to correlate the PostX'd assemblies with Neos's `Engine.ExtraAssemblies`. ExtraAssemblies is a list of the loaded plugins, but it only contains their filenames. No path information.
3. Do some set theory to check for assemblies we couldn't match to plugins and plugins we couldn't match to assemblies.
   - assemblies we couldn't match to plugins aren't a huge deal, and we actually expect a few of these. Specifically, NeosModLoader, FrooxEngine, and BusinessX are all PostX'd assemblies we shouldn't treat as plugins. Anything not in this expected set I warn about.
   -  plugins we couldn't match to assemblies are a bigger deal, and indicate that my plugin detection code failed. We can't version spoof properly in this case.
4. Deal with the Unsafe and AdvertiseVersion configs
5. Make sure I sort the assemblies in the same order Froox does
6. Spoof the version string and the compatibility hash, but this time respecting plugins