### PR TITLE
Fix assembly loading on windows headless

### DIFF
--- a/NeosModLoader/AssemblyLoader.cs
+++ b/NeosModLoader/AssemblyLoader.cs
@@ -49,7 +49,7 @@ namespace NeosModLoader
 			try
 			{
 				Logger.DebugFuncInternal(() => $"load assembly {filename}");
-				assembly = Assembly.LoadFile(filepath);
+				assembly = Assembly.LoadFrom(filepath);
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
This fixes #53.

I don't know why. I don't know how. Send help.

Look at these docs. Nothing in them has a big ol "danger this will just be broken in some cases" label. WTF.  
[Assembly.LoadFrom](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.loadfrom?view=net-6.0)  
[Assembly.LoadFile](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.loadfile?view=net-6.0)