### PR TITLE
Attempt to fix a config autosave NRE

### DIFF
--- a/NeosModLoader/ModConfiguration.cs
+++ b/NeosModLoader/ModConfiguration.cs
@@ -671,7 +671,14 @@ namespace NeosModLoader
 				.Where(config => config!.AnyValuesSet())
 				.Do(config =>
 				{
-					config!.Save();
+					try
+					{
+						config!.Save();
+					}
+					catch (Exception e)
+					{
+						Logger.ErrorInternal($"Error saving configuration for {config!.Owner.Name}:\n{e}");
+					}
 					count += 1;
 				});
 			Logger.MsgInternal($"Configs saved for {count} mods.");

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -25,8 +25,8 @@ namespace NeosModLoader
 			StackTrace stackTrace = new(2 + nmlCalleeDepth);
 			for (int i = 0; i < stackTrace.FrameCount; i++)
 			{
-				Assembly assembly = stackTrace.GetFrame(i).GetMethod().DeclaringType.Assembly;
-				if (ModLoader.AssemblyLookupMap.TryGetValue(assembly, out NeosMod mod))
+				Assembly? assembly = stackTrace.GetFrame(i)?.GetMethod()?.DeclaringType?.Assembly;
+				if (assembly != null && ModLoader.AssemblyLookupMap.TryGetValue(assembly, out NeosMod mod))
 				{
 					return mod;
 				}


### PR DESCRIPTION
SectOLT back with another fun bug:

```log
Restoring currently updating root. Stack:


   at void FrooxEngine.UpdateManager.RestoreRootCurrentlyUpdating() in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/Data%20Model/Controllers/UpdateManager.cs:line 141
   at bool FrooxEngine.UpdateManager.RunUpdates() in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/Data%20Model/Controllers/UpdateManager.cs:line 470
   at bool FrooxEngine.World.RefreshStep() in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/World.cs:line 1588
   at bool FrooxEngine.World.Refresh() in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/World.cs:line 1257
   at void FrooxEngine.WorldManager.UpdateStep(double maxMilliseconds) in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/WorldManager.cs:line 622
   at bool FrooxEngine.WorldManager.RunUpdateLoop(double maxMilliseconds) in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/WorldManager.cs:line 419
   at void FrooxEngine.Engine.UpdateStep(double maxMilliseconds) in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/Engine.cs:line 1206
   at void FrooxEngine.Engine.RunUpdateLoop(double maxMilliseconds) in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/Engine.cs:line 1044
   at void FrooxEngine.StandaloneFrooxEngineRunner.UpdateLoop() in C:/Sync/Projects/Software/Applications/NeoS/NeosFramework/FrooxEngine/Engine/StandaloneFrooxEngineRunner.cs:line 163
   at void System.Threading.ThreadHelper.ThreadStart()
Exception when Updating object: Element: ID5F000, Type: FrooxEngine.NeosEnder, World: SectHeadless World 2, IsRemoved: False, IsDestroyed: False, IsDisposed: False, Enabled: True
Element: ID5E500, Type: FrooxEngine.Slot, World: SectHeadless World 2, IsRemoved: False, Slot name: Ender, T: [0; 0; 0], R: [0; 0; 0; 1], S: [1; 1; 1], ActiveSelf: True, IsDestroyed: False
Element: ID2100, Type: FrooxEngine.Slot, World: SectHeadless World 2, IsRemoved: False, Slot name: Root, T: [0; 0; 0], R: [0; 0; 0; 1], S: [1; 1; 1], ActiveSelf: True, IsDestroyed: False
Element: ID0, Type: FrooxEngine.World, World: SectHeadless World 2, IsRemoved: False


Exception:
System.NullReferenceException: Object reference not set to an instance of an object.
   at NeosModLoader.Util.ExecutingMod(Int32 nmlCalleeDepth)
   at NeosModLoader.ModConfiguration.Save(Boolean saveDefaultValues, Boolean immediate)
   at NeosModLoader.ModConfiguration.<>c__DisplayClass50_0.<ShutdownHook>b__4(ModConfiguration config)
   at HarmonyLib.CollectionExtensions.Do[T](IEnumerable`1 sequence, Action`1 action)
   at NeosModLoader.ModConfiguration.ShutdownHook()
   at FrooxEngine.Engine.Shutdown_Patch1(Engine this)
   at FrooxEngine.NeosEnder.OnCommonUpdate() in C:\Sync\Projects\Software\Applications\NeoS\NeosFramework\FrooxEngine\Userspace\Userspace\NeosEnder.cs:line 47
   at FrooxEngine.ComponentBase`1.InternalRunUpdate() in C:\Sync\Projects\Software\Applications\NeoS\NeosFramework\FrooxEngine\Data Model\Base Classes\ComponentBase.cs:line 541
   at FrooxEngine.UpdateManager.RunUpdates() in C:\Sync\Projects\Software\Applications\NeoS\NeosFramework\FrooxEngine\Data Model\Controllers\UpdateManager.cs:line 469
```

This time it's a NRE being thrown somewhere in Util.ExecutingMod, which is wild as I didn't know that was possible. I've aggressively tried to catch it in this PR, which appears to work as SectOLT says it's not throwing exceptions anymore.