### PR TITLE
Allow loading of mods with unloadable types

### DIFF
--- a/NeosModLoader/AssemblyHider.cs
+++ b/NeosModLoader/AssemblyHider.cs
@@ -3,6 +3,7 @@ using FrooxEngine;
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace NeosModLoader
@@ -39,6 +40,11 @@ namespace NeosModLoader
 				MethodInfo getTypeTarget = AccessTools.DeclaredMethod(typeof(WorkerManager), nameof(WorkerManager.GetType));
 				MethodInfo getTypePatch = AccessTools.DeclaredMethod(typeof(AssemblyHider), nameof(FindTypePostfix));
 				harmony.Patch(getTypeTarget, postfix: new HarmonyMethod(getTypePatch));
+
+				// FrooxEngine likes to enumerate all types in all assemblies, which is prone to issues (such as crashing FrooxCode if a type isn't loadable)
+				MethodInfo getAssembliesTarget = AccessTools.DeclaredMethod(typeof(AppDomain), nameof(AppDomain.GetAssemblies));
+				MethodInfo getAssembliesPatch = AccessTools.DeclaredMethod(typeof(AssemblyHider), nameof(GetAssembliesPostfix));
+				harmony.Patch(getAssembliesTarget, postfix: new HarmonyMethod(getAssembliesPatch));
 			}
 		}
 
@@ -64,20 +70,23 @@ namespace NeosModLoader
 			return assemblies;
 		}
 
-		private static bool IsModType(Type type)
+		private static bool IsModAssembly(Assembly assembly, string typeOrAssembly, string name, bool log, bool forceShowLate)
 		{
-			if (neosAssemblies!.Contains(type.Assembly))
+			if (neosAssemblies!.Contains(assembly))
 			{
 				// the type belongs to a Neos assembly
-				return false; // don't hide the type
+				return false; // don't hide the thing
 			}
 			else
 			{
-				if (modAssemblies!.Contains(type.Assembly))
+				if (modAssemblies!.Contains(assembly))
 				{
 					// known type from a mod assembly
-					Logger.DebugInternal($"Hid type \"{type}\" from Neos");
-					return true; // hide the type
+					if (log)
+					{
+						Logger.DebugInternal($"Hid {typeOrAssembly} \"{name}\" from Neos");
+					}
+					return true; // hide the thing
 				}
 				else
 				{
@@ -86,10 +95,24 @@ namespace NeosModLoader
 					// this is super weird, and probably shouldn't ever happen... but if it does, I want to know about it.
 					// since this is an edge case users may want to handle in different ways, the HideLateTypes nml config option allows them to choose.
 					bool hideLate = ModLoaderConfiguration.Get().HideLateTypes;
-					Logger.WarnInternal($"The \"{type}\" type does not appear to part of Neos or a mod. It is unclear whether it should be hidden or not. Due to the HideLateTypes config option being {hideLate} it will be {(hideLate ? "Hidden" : "Shown")}");
-					return hideLate; // hide the type only if hideLate == true
+					if (log)
+					{
+						Logger.WarnInternal($"The \"{name}\" {typeOrAssembly} does not appear to part of Neos or a mod. It is unclear whether it should be hidden or not. Due to the HideLateTypes config option being {hideLate} it will be {(hideLate ? "Hidden" : "Shown")}");
+					}
+					return hideLate && forceShowLate; // hide the thing only if hideLate == true
 				}
 			}
+		}
+
+		private static bool IsModAssembly(Assembly assembly, bool forceShowLate = false)
+		{
+			// this generates a lot of logspam, as a single call to AppDomain.GetAssemblies() calls this many times
+			return IsModAssembly(assembly, "assembly", assembly.ToString(), false, forceShowLate);
+		}
+
+		private static bool IsModType(Type type)
+		{
+			return IsModAssembly(type.Assembly, "type", type.ToString(), true, false);
 		}
 
 		// postfix for a method that searches for a type, and returns a reference to it if found (TypeHelper.FindType and WorkerManager.GetType)
@@ -115,6 +138,19 @@ namespace NeosModLoader
 				{
 					__result = false;
 				}
+			}
+		}
+
+		private static void GetAssembliesPostfix(ref Assembly[] __result)
+		{
+			Assembly? callingAssembly = Util.GetCallingAssembly();
+			if (callingAssembly != null && neosAssemblies!.Contains(callingAssembly))
+			{
+				// if we're being called by Neos, then hide mod assemblies
+				Logger.DebugFuncInternal(() => $"Intercepting call to AppDomain.GetAssemblies() from {callingAssembly}");
+				__result = __result
+					.Where(assembly => !IsModAssembly(assembly, true)) // it turns out Neos itself late-loads a bunch of stuff, so we force-show late-loaded assemblies here
+					.ToArray();
 			}
 		}
 	}

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -10,7 +10,7 @@ namespace NeosModLoader
 {
 	public class ModLoader
 	{
-		internal const string VERSION_CONSTANT = "1.12.5";
+		internal const string VERSION_CONSTANT = "1.12.6";
 		/// <summary>
 		/// NeosModLoader's version
 		/// </summary>
@@ -174,7 +174,7 @@ namespace NeosModLoader
 				return null;
 			}
 
-			Type[] modClasses = mod.Assembly.GetTypes().Where(t => t.IsClass && !t.IsAbstract && NEOS_MOD_TYPE.IsAssignableFrom(t)).ToArray();
+			Type[] modClasses = mod.Assembly.GetLoadableTypes(t => t.IsClass && !t.IsAbstract && NEOS_MOD_TYPE.IsAssignableFrom(t)).ToArray();
 			if (modClasses.Length == 0)
 			{
 				Logger.ErrorInternal($"no mods found in {mod.File}");

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -148,7 +148,7 @@ namespace NeosModLoader
 			}
 			catch (Exception e)
 			{
-				Logger.DebugInternal("Could not read the name for a type.");
+				Logger.DebugFuncInternal(() => $"Could not read the name for a type: {e}");
 				return false;
 			}
 			try

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Threading;
@@ -34,6 +35,25 @@ namespace NeosModLoader
 			return null;
 		}
 
+		/// <summary>
+		/// Get the calling assembly by stack trace analysis. Always skips the first one frame, being this method and you, the caller.
+		/// </summary>
+		/// <param name="skipFrames">The number of extra frame skip in the stack</param>
+		/// <returns>The executing mod, or null if none found</returns>
+		internal static Assembly? GetCallingAssembly(int skipFrames = 0)
+		{
+			// same logic as ExecutingMod(), but simpler case
+			StackTrace stackTrace = new(2 + skipFrames);
+			for (int i = 0; i < stackTrace.FrameCount; i++)
+			{
+				Assembly? assembly = stackTrace.GetFrame(i)?.GetMethod()?.DeclaringType?.Assembly;
+				if (assembly != null)
+				{
+					return assembly;
+				}
+			}
+			return null;
+		}
 
 		/// <summary>
 		/// Used to debounce a method call. The underlying method will be called after there have been no additional calls
@@ -102,5 +122,57 @@ namespace NeosModLoader
 			return !CannotBeNull(t);
 		}
 
+		internal static IEnumerable<Type> GetLoadableTypes(this Assembly assembly, Predicate<Type> predicate)
+		{
+			try
+			{
+				return assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException e)
+			{
+				return e.Types.Where(type => CheckType(type, predicate));
+			}
+		}
+
+		// check a potentially unloadable type to see if it is (A) loadable and (B) satsifies a predicate without throwing an exception
+		// this does a series of increasingly aggressive checks to see if the type is unsafe to touch
+		private static bool CheckType(Type type, Predicate<Type> predicate)
+		{
+			if (type == null)
+			{
+				return false;
+			}
+			try
+			{
+				string _name = type.Name;
+			}
+			catch (Exception e)
+			{
+				Logger.DebugInternal("Could not read the name for a type.");
+				return false;
+			}
+			try
+			{
+				if (type.TypeInitializer == null)
+				{
+					return false;
+				}
+			}
+			catch (Exception e)
+			{
+				Logger.DebugFuncInternal(() => $"Could not read TypeInitializer for type \"{type.Name}\": {e}");
+				return false;
+			}
+
+			try
+			{
+				return predicate(type);
+			}
+			catch (Exception e)
+			{
+				Logger.DebugFuncInternal(() => $"Could not load type \"{type.Name}\": {e}");
+				return false;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Short story: this fixes https://github.com/New-Project-Final-Final-WIP/HeadlessTweaks/issues/4.

Long story: It turns out some mods have types that cannot be loaded at runtime, because assemblies they depend on are in turn not loaded. .NET *really* doesn't like if you try to inspect those types with reflection, which both NML and Neos try to do. Two things were done to fix this:

1. ModLoader.cs now loads types through an alternate, safer mechanism (that's an evil hack involving slinging a bunch of exceptions around)
2. If Neos tries to call `AppDomain.CurrentDomain.GetAssemblies()` we intercept that and filter out mod assemblies

With these fixes in place I've confirmed that HeadlessTweaks no longer crashes on Windows headless.

