### PR TITLE
Fix a bug in GetLoadableTypes

### DIFF
--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -126,7 +126,7 @@ namespace NeosModLoader
 		{
 			try
 			{
-				return assembly.GetTypes();
+				return assembly.GetTypes().Where(type => CheckType(type, predicate));
 			}
 			catch (ReflectionTypeLoadException e)
 			{


### PR DESCRIPTION
This bug caused all mods with more than one type that also lack any unloadable types to fail to load.