### PR TITLE
Remove typeinitializer check

### DIFF
--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -151,18 +151,6 @@ namespace NeosModLoader
 				Logger.DebugFuncInternal(() => $"Could not read the name for a type: {e}");
 				return false;
 			}
-			try
-			{
-				if (type.TypeInitializer == null)
-				{
-					return false;
-				}
-			}
-			catch (Exception e)
-			{
-				Logger.DebugFuncInternal(() => $"Could not read TypeInitializer for type \"{type.Name}\": {e}");
-				return false;
-			}
 
 			try
 			{


### PR DESCRIPTION
It turns out that this wasn't needed, and in fact it causes problems as NeosMod implementations don't actually *need* a TypeInitializer. This code was preventing certain mods from loading.