### PR TITLE
Various Logging Fixes

### DIFF
--- a/NeosModLoader/AssemblyHider.cs
+++ b/NeosModLoader/AssemblyHider.cs
@@ -165,7 +165,7 @@ namespace NeosModLoader
 
 		private static void GetAssembliesPostfix(ref Assembly[] __result)
 		{
-			Assembly? callingAssembly = Util.GetCallingAssembly();
+			Assembly? callingAssembly = Util.GetCallingAssembly(new(1));
 			if (callingAssembly != null && neosAssemblies!.Contains(callingAssembly))
 			{
 				// if we're being called by Neos, then hide mod assemblies

--- a/NeosModLoader/AssemblyHider.cs
+++ b/NeosModLoader/AssemblyHider.cs
@@ -3,6 +3,7 @@ using FrooxEngine;
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -10,8 +11,40 @@ namespace NeosModLoader
 {
 	internal static class AssemblyHider
 	{
+		/// <summary>
+		/// Companies that indicate an assembly is part of .NET.
+		/// This list was found by debug logging the AssemblyCompanyAttribute for all loaded assemblies.
+		/// </summary>
+		private static HashSet<string> knownDotNetCompanies = new List<string>()
+		{
+			"Mono development team", // used by .NET stuff and Mono.Security
+		}.Select(company => company.ToLower()).ToHashSet();
+
+		/// <summary>
+		/// Products that indicate an assembly is part of .NET.
+		/// This list was found by debug logging the AssemblyProductAttribute for all loaded assemblies.
+		/// </summary>
+		private static HashSet<string> knownDotNetProducts = new List<string>()
+		{
+			"Microsoft® .NET", // used by a few System.* assemblies
+			"Microsoft® .NET Framework", // used by most of the System.* assemblies
+			"Mono Common Language Infrastructure", // used by mscorlib stuff
+		}.Select(product => product.ToLower()).ToHashSet();
+
+		/// <summary>
+		/// Assemblies that were already loaded when NML started up, minus a couple known non-Neos assemblies.
+		/// </summary>
 		private static HashSet<Assembly>? neosAssemblies;
+
+		/// <summary>
+		/// Assemblies that 100% exist due to a mod
+		/// </summary>
 		private static HashSet<Assembly>? modAssemblies;
+
+		/// <summary>
+		/// .NET assembiles we want to ignore in some cases, like the callee check for the AppDomain.GetAssemblies() patch
+		/// </summary>
+		private static HashSet<Assembly>? dotNetAssemblies;
 
 		/// <summary>
 		/// Patch Neos's type lookup code to not see mod-related types. This is needed, because users can pass
@@ -23,26 +56,28 @@ namespace NeosModLoader
 		{
 			if (ModLoaderConfiguration.Get().HideModTypes)
 			{
+				// initialize the static assembly sets that our patches will need later
 				neosAssemblies = GetNeosAssemblies(initialAssemblies);
-				modAssemblies = GetModAssemblies();
+				modAssemblies = GetModAssemblies(neosAssemblies);
+				dotNetAssemblies = neosAssemblies.Where(LooksLikeDotNetAssembly).ToHashSet();
 
 				// TypeHelper.FindType explicitly does a type search
-				MethodInfo findTypeTarget = AccessTools.DeclaredMethod(typeof(TypeHelper), nameof(TypeHelper.FindType));
+				MethodInfo findTypeTarget = AccessTools.DeclaredMethod(typeof(TypeHelper), nameof(TypeHelper.FindType), new Type[] { typeof(string) });
 				MethodInfo findTypePatch = AccessTools.DeclaredMethod(typeof(AssemblyHider), nameof(FindTypePostfix));
 				harmony.Patch(findTypeTarget, postfix: new HarmonyMethod(findTypePatch));
 
 				// WorkerManager.IsValidGenericType checks a type for validity, and if it returns `true` it reveals that the type exists
-				MethodInfo isValidGenericTypeTarget = AccessTools.DeclaredMethod(typeof(WorkerManager), nameof(WorkerManager.IsValidGenericType));
+				MethodInfo isValidGenericTypeTarget = AccessTools.DeclaredMethod(typeof(WorkerManager), nameof(WorkerManager.IsValidGenericType), new Type[] { typeof(Type), typeof(bool) });
 				MethodInfo isValidGenericTypePatch = AccessTools.DeclaredMethod(typeof(AssemblyHider), nameof(IsValidTypePostfix));
 				harmony.Patch(isValidGenericTypeTarget, postfix: new HarmonyMethod(isValidGenericTypePatch));
 
 				// WorkerManager.GetType uses FindType, but upon failure fails back to doing a (strangely) exhausitive reflection-based search for the type
-				MethodInfo getTypeTarget = AccessTools.DeclaredMethod(typeof(WorkerManager), nameof(WorkerManager.GetType));
+				MethodInfo getTypeTarget = AccessTools.DeclaredMethod(typeof(WorkerManager), nameof(WorkerManager.GetType), new Type[] { typeof(string) });
 				MethodInfo getTypePatch = AccessTools.DeclaredMethod(typeof(AssemblyHider), nameof(FindTypePostfix));
 				harmony.Patch(getTypeTarget, postfix: new HarmonyMethod(getTypePatch));
 
 				// FrooxEngine likes to enumerate all types in all assemblies, which is prone to issues (such as crashing FrooxCode if a type isn't loadable)
-				MethodInfo getAssembliesTarget = AccessTools.DeclaredMethod(typeof(AppDomain), nameof(AppDomain.GetAssemblies));
+				MethodInfo getAssembliesTarget = AccessTools.DeclaredMethod(typeof(AppDomain), nameof(AppDomain.GetAssemblies), new Type[] { });
 				MethodInfo getAssembliesPatch = AccessTools.DeclaredMethod(typeof(AssemblyHider), nameof(GetAssembliesPostfix));
 				harmony.Patch(getAssembliesTarget, postfix: new HarmonyMethod(getAssembliesPatch));
 			}
@@ -59,14 +94,15 @@ namespace NeosModLoader
 			return initialAssemblies;
 		}
 
-		private static HashSet<Assembly> GetModAssemblies()
+		private static HashSet<Assembly> GetModAssemblies(HashSet<Assembly> neosAssemblies)
 		{
 			// start with ALL assemblies
 			HashSet<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies().ToHashSet();
 
-			// remove assemblies that already existed before NML loaded
+			// remove assemblies that we know to have come with Neos
 			assemblies.ExceptWith(neosAssemblies);
 
+			// what's left are assemblies that magically appeared during the mod loading process. So mods and their dependencies.
 			return assemblies;
 		}
 
@@ -165,15 +201,55 @@ namespace NeosModLoader
 
 		private static void GetAssembliesPostfix(ref Assembly[] __result)
 		{
-			Assembly? callingAssembly = Util.GetCallingAssembly(new(1));
+			Assembly? callingAssembly = GetCallingAssembly(new(1));
 			if (callingAssembly != null && neosAssemblies!.Contains(callingAssembly))
 			{
-				// if we're being called by Neos, then hide mod assemblies
+				// if we're being called by Neos code, then hide mod assemblies
 				Logger.DebugFuncInternal(() => $"Intercepting call to AppDomain.GetAssemblies() from {callingAssembly}");
 				__result = __result
 					.Where(assembly => !IsModAssembly(assembly, forceShowLate: true)) // it turns out Neos itself late-loads a bunch of stuff, so we force-show late-loaded assemblies here
 					.ToArray();
 			}
+		}
+
+		/// <summary>
+		/// Get the calling assembly by stack trace analysis, ignoring .NET assemblies.
+		/// This implementation is SPECIFICALLY for the AppDomain.GetAssemblies() patch and may not be valid for other use-cases.
+		/// </summary>
+		/// <param name="stacktrace">A stack trace captured by the callee</param>
+		/// <returns>The executing assembly, or null if none found</returns>
+		private static Assembly? GetCallingAssembly(StackTrace stackTrace)
+		{
+			for (int i = 0; i < stackTrace.FrameCount; i++)
+			{
+				Assembly? assembly = stackTrace.GetFrame(i)?.GetMethod()?.DeclaringType?.Assembly;
+				// .NET calls AppDomain.GetAssemblies() a bunch internally, and we don't want to intercept those calls UNLESS they originated from Neos code.
+				if (assembly != null && !dotNetAssemblies!.Contains(assembly))
+				{
+					return assembly;
+				}
+			}
+			return null;
+		}
+
+		private static bool LooksLikeDotNetAssembly(Assembly assembly)
+		{
+			// check the assembly's company
+			string? company = assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company;
+			if (company != null && knownDotNetCompanies.Contains(company.ToLower()))
+			{
+				return true;
+			}
+
+			// check the assembly's product
+			string? product = assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product;
+			if (product != null && knownDotNetProducts.Contains(product.ToLower()))
+			{
+				return true;
+			}
+
+			// nothing matched, this is probably not part of .NET
+			return false;
 		}
 	}
 }

--- a/NeosModLoader/AssemblyHider.cs
+++ b/NeosModLoader/AssemblyHider.cs
@@ -93,7 +93,7 @@ namespace NeosModLoader
 					// known type from a mod assembly
 					if (log)
 					{
-						Logger.DebugInternal($"Hid {typeOrAssembly} \"{name}\" from Neos");
+						Logger.DebugFuncInternal(() => $"Hid {typeOrAssembly} \"{name}\" from Neos");
 					}
 					return true; // hide the thing
 				}

--- a/NeosModLoader/Logger.cs
+++ b/NeosModLoader/Logger.cs
@@ -1,5 +1,6 @@
 using BaseX;
 using System;
+using System.Diagnostics;
 
 namespace NeosModLoader
 {
@@ -25,7 +26,7 @@ namespace NeosModLoader
 		{
 			if (IsDebugEnabled())
 			{
-				LogInternal(LogType.DEBUG, messageProducer(), SourceFromStackTrace());
+				LogInternal(LogType.DEBUG, messageProducer(), SourceFromStackTrace(new(1)));
 			}
 		}
 
@@ -41,7 +42,7 @@ namespace NeosModLoader
 		{
 			if (IsDebugEnabled())
 			{
-				LogInternal(LogType.DEBUG, message, SourceFromStackTrace());
+				LogInternal(LogType.DEBUG, message, SourceFromStackTrace(new(1)));
 			}
 		}
 
@@ -49,19 +50,19 @@ namespace NeosModLoader
 		{
 			if (IsDebugEnabled())
 			{
-				LogListInternal(LogType.DEBUG, messages, SourceFromStackTrace());
+				LogListInternal(LogType.DEBUG, messages, SourceFromStackTrace(new(1)));
 			}
 		}
 
 		internal static void MsgInternal(string message) => LogInternal(LogType.INFO, message);
-		internal static void MsgExternal(object message) => LogInternal(LogType.INFO, message, SourceFromStackTrace());
-		internal static void MsgListExternal(object[] messages) => LogListInternal(LogType.INFO, messages, SourceFromStackTrace());
+		internal static void MsgExternal(object message) => LogInternal(LogType.INFO, message, SourceFromStackTrace(new(1)));
+		internal static void MsgListExternal(object[] messages) => LogListInternal(LogType.INFO, messages, SourceFromStackTrace(new(1)));
 		internal static void WarnInternal(string message) => LogInternal(LogType.WARN, message);
-		internal static void WarnExternal(object message) => LogInternal(LogType.WARN, message, SourceFromStackTrace());
-		internal static void WarnListExternal(object[] messages) => LogListInternal(LogType.WARN, messages, SourceFromStackTrace());
+		internal static void WarnExternal(object message) => LogInternal(LogType.WARN, message, SourceFromStackTrace(new(1)));
+		internal static void WarnListExternal(object[] messages) => LogListInternal(LogType.WARN, messages, SourceFromStackTrace(new(1)));
 		internal static void ErrorInternal(string message) => LogInternal(LogType.ERROR, message);
-		internal static void ErrorExternal(object message) => LogInternal(LogType.ERROR, message, SourceFromStackTrace());
-		internal static void ErrorListExternal(object[] messages) => LogListInternal(LogType.ERROR, messages, SourceFromStackTrace());
+		internal static void ErrorExternal(object message) => LogInternal(LogType.ERROR, message, SourceFromStackTrace(new(1)));
+		internal static void ErrorListExternal(object[] messages) => LogListInternal(LogType.ERROR, messages, SourceFromStackTrace(new(1)));
 
 		private static void LogInternal(string logTypePrefix, object message, string? source = null)
 		{
@@ -94,10 +95,10 @@ namespace NeosModLoader
 			}
 		}
 
-		private static string? SourceFromStackTrace()
+		private static string? SourceFromStackTrace(StackTrace stackTrace)
 		{
 			// MsgExternal() and Msg() are above us in the stack
-			return Util.ExecutingMod(2)?.Name;
+			return Util.ExecutingMod(stackTrace)?.Name;
 		}
 
 		private sealed class LogType

--- a/NeosModLoader/ModConfiguration.cs
+++ b/NeosModLoader/ModConfiguration.cs
@@ -527,7 +527,7 @@ namespace NeosModLoader
 		{
 
 			Thread thread = Thread.CurrentThread;
-			NeosMod? callee = Util.ExecutingMod();
+			NeosMod? callee = Util.ExecutingMod(new(1));
 			Action<bool>? saveAction = null;
 
 			// get saved state for this callee

--- a/NeosModLoader/NeosVersionReset.cs
+++ b/NeosModLoader/NeosVersionReset.cs
@@ -40,14 +40,13 @@ namespace NeosModLoader
 				.Where(IsPostXProcessed)
 				.ToArray();
 
-			if (Logger.IsDebugEnabled())
+			Logger.DebugFuncInternal(() =>
 			{
 				string potentialPlugins = postxedAssemblies
 					.Select(a => Path.GetFileName(a.Location))
 					.Join(delimiter: ", ");
-
-				Logger.DebugInternal($"Found {postxedAssemblies.Length} potential plugins: {potentialPlugins}");
-			}
+				return $"Found {postxedAssemblies.Length} potential plugins: {potentialPlugins}";
+			});
 
 			HashSet<Assembly> expectedPostXAssemblies = GetExpectedPostXAssemblies();
 
@@ -71,11 +70,12 @@ namespace NeosModLoader
 				})
 				.ToArray();
 
-			if (Logger.IsDebugEnabled())
+
+			Logger.DebugFuncInternal(() =>
 			{
 				string actualPlugins = plugins.Keys.Join(delimiter: ", ");
-				Logger.DebugInternal($"Found {plugins.Count} actual plugins: {actualPlugins}");
-			}
+				return $"Found {plugins.Count} actual plugins: {actualPlugins}";
+			});
 
 			// warn about the assemblies we couldn't map to plugins
 			foreach (Assembly assembly in unmatchedAssemblies)

--- a/NeosModLoader/NeosVersionReset.cs
+++ b/NeosModLoader/NeosVersionReset.cs
@@ -40,11 +40,14 @@ namespace NeosModLoader
 				.Where(IsPostXProcessed)
 				.ToArray();
 
-			string potentialPlugins = postxedAssemblies
-				.Select(a => Path.GetFileName(a.Location))
-				.Join(delimiter: ", ");
+			if (Logger.IsDebugEnabled())
+			{
+				string potentialPlugins = postxedAssemblies
+					.Select(a => Path.GetFileName(a.Location))
+					.Join(delimiter: ", ");
 
-			Logger.DebugFuncInternal(() => $"Found {postxedAssemblies.Length} potential plugins: {potentialPlugins}");
+				Logger.DebugInternal($"Found {postxedAssemblies.Length} potential plugins: {potentialPlugins}");
+			}
 
 			HashSet<Assembly> expectedPostXAssemblies = GetExpectedPostXAssemblies();
 
@@ -68,8 +71,11 @@ namespace NeosModLoader
 				})
 				.ToArray();
 
-			string actualPlugins = plugins.Keys.Join(delimiter: ", ");
-			Logger.DebugFuncInternal(() => $"Found {plugins.Count} actual plugins: {actualPlugins}");
+			if (Logger.IsDebugEnabled())
+			{
+				string actualPlugins = plugins.Keys.Join(delimiter: ", ");
+				Logger.DebugInternal($"Found {plugins.Count} actual plugins: {actualPlugins}");
+			}
 
 			// warn about the assemblies we couldn't map to plugins
 			foreach (Assembly assembly in unmatchedAssemblies)

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -155,12 +155,13 @@ namespace NeosModLoader
 			{
 				if (type.TypeInitializer == null)
 				{
+					Logger.DebugFuncInternal(() => $"No TypeInitializer for type \"{type}\"");
 					return false;
 				}
 			}
 			catch (Exception e)
 			{
-				Logger.DebugFuncInternal(() => $"Could not read TypeInitializer for type \"{type.Name}\": {e}");
+				Logger.DebugFuncInternal(() => $"Could not read TypeInitializer for type \"{type}\": {e}");
 				return false;
 			}
 
@@ -170,7 +171,7 @@ namespace NeosModLoader
 			}
 			catch (Exception e)
 			{
-				Logger.DebugFuncInternal(() => $"Could not load type \"{type.Name}\": {e}");
+				Logger.DebugFuncInternal(() => $"Could not load type \"{type}\": {e}");
 				return false;
 			}
 		}

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -32,25 +32,6 @@ namespace NeosModLoader
 		}
 
 		/// <summary>
-		/// Get the calling assembly by stack trace analysis.
-		/// </summary>
-		/// <param name="stacktrace">A stack trace captured by the callee</param>
-		/// <returns>The executing mod, or null if none found</returns>
-		internal static Assembly? GetCallingAssembly(StackTrace stackTrace)
-		{
-			// same logic as ExecutingMod(), but simpler case
-			for (int i = 0; i < stackTrace.FrameCount; i++)
-			{
-				Assembly? assembly = stackTrace.GetFrame(i)?.GetMethod()?.DeclaringType?.Assembly;
-				if (assembly != null)
-				{
-					return assembly;
-				}
-			}
-			return null;
-		}
-
-		/// <summary>
 		/// Used to debounce a method call. The underlying method will be called after there have been no additional calls
 		/// for n milliseconds.
 		/// 

--- a/NeosModLoader/Util.cs
+++ b/NeosModLoader/Util.cs
@@ -13,17 +13,13 @@ namespace NeosModLoader
 	internal static class Util
 	{
 		/// <summary>
-		/// Get the executing mod by stack trace analysis. Always skips the first two frames, being this method and you, the caller.
+		/// Get the executing mod by stack trace analysis.
 		/// You may skip extra frames if you know your callers are guaranteed to be NML code.
 		/// </summary>
-		/// <param name="nmlCalleeDepth">The number NML method calls above you in the stack</param>
+		/// <param name="stackTrace">A stack trace captured by the callee</param>
 		/// <returns>The executing mod, or null if none found</returns>
-		internal static NeosMod? ExecutingMod(int nmlCalleeDepth = 0)
+		internal static NeosMod? ExecutingMod(StackTrace stackTrace)
 		{
-			// example: ExecutingMod(), SourceFromStackTrace(), MsgExternal(), Msg(), ACTUAL MOD CODE
-			// you'd skip 4 frames
-			// we always skip ExecutingMod() and whoever called us (as this is an internal method), which is where the 2 comes from
-			StackTrace stackTrace = new(2 + nmlCalleeDepth);
 			for (int i = 0; i < stackTrace.FrameCount; i++)
 			{
 				Assembly? assembly = stackTrace.GetFrame(i)?.GetMethod()?.DeclaringType?.Assembly;
@@ -36,14 +32,13 @@ namespace NeosModLoader
 		}
 
 		/// <summary>
-		/// Get the calling assembly by stack trace analysis. Always skips the first one frame, being this method and you, the caller.
+		/// Get the calling assembly by stack trace analysis.
 		/// </summary>
-		/// <param name="skipFrames">The number of extra frame skip in the stack</param>
+		/// <param name="stacktrace">A stack trace captured by the callee</param>
 		/// <returns>The executing mod, or null if none found</returns>
-		internal static Assembly? GetCallingAssembly(int skipFrames = 0)
+		internal static Assembly? GetCallingAssembly(StackTrace stackTrace)
 		{
 			// same logic as ExecutingMod(), but simpler case
-			StackTrace stackTrace = new(2 + skipFrames);
 			for (int i = 0; i < stackTrace.FrameCount; i++)
 			{
 				Assembly? assembly = stackTrace.GetFrame(i)?.GetMethod()?.DeclaringType?.Assembly;


### PR DESCRIPTION
This does the following:

- Minor logging cleanup
- Capture stack traces at top level vs doing frame-skipping arithmetic. I think this is actually mandatory as I was seeing some strange logging behavior on Windows Headless that I can only explain if .NET was inlining method calls, which obviously would ruin my "skip 4 frames" style of arithmetic.
- Stop intercepting internal .NET calls to `AppDomain.GetAssemblies()`. It turns out that .NET calls this a lot internally, and my logic that was *supposed* to be intercepting FrooxEngine calls was also messing with internal .NET calls not initiated by FrooxEngine. I've implemented a smarter stack frame search to solve this.