### PR TITLE
Save configs synchronously on shutdown

### DIFF
--- a/NeosModLoader/ModConfiguration.cs
+++ b/NeosModLoader/ModConfiguration.cs
@@ -519,7 +519,7 @@ namespace NeosModLoader
 
 
 		/// <summary>
-		/// Persist this configuration to disk. This method is not called automatically.
+		/// Asynchronously persist this configuration to disk.
 		/// </summary>
 		/// <param name="saveDefaultValues">If true, default values will also be persisted</param>
 		/// <param name="immediate">Skip the debouncing and save immediately</param>
@@ -583,8 +583,11 @@ namespace NeosModLoader
 			}
 		}
 
-		// performs the actual, synchronous save
-		private void SaveInternal(bool saveDefaultValues)
+		/// <summary>
+		/// performs the actual, synchronous save
+		/// </summary>
+		/// <param name="saveDefaultValues">If true, default values will also be persisted</param>
+		private void SaveInternal(bool saveDefaultValues = false)
 		{
 			Stopwatch stopwatch = Stopwatch.StartNew();
 			JObject json = new()
@@ -680,7 +683,8 @@ namespace NeosModLoader
 				{
 					try
 					{
-						config!.Save();
+						// synchronously save the config
+						config!.SaveInternal();
 					}
 					catch (Exception e)
 					{


### PR DESCRIPTION
The original mod configuration implementation saved synchronously, but in #38 *all* config saving was switched over to a background thread. While doing some unrelated debugging I noticed that the shutdown hook saves were also asynchronous, and it struck me as incorrect and dangerous.

It's pretty typical for 10s of mods to save configs on shutdown, and I don't think there's a compelling performance benefit to doing all that IO concurrently. However, I *do* think there's a compelling safety benefit to doing all the saves synchronously: I believe Task.Run() uses background threads, which do not keep the managed execution environment running. In other words, there's no guarantee those background saves won't get interrupted. Doing the saves synchronously ensures they'll actually finish before Neos exits.