### PR TITLE
Implement #75 - Command Line Argument parsing utility and config

### DIFF
--- a/NeosModLoader/ModLoaderConfiguration.cs
+++ b/NeosModLoader/ModLoaderConfiguration.cs
@@ -1,23 +1,87 @@
+using HarmonyLib;
+using NeosModLoader.Utility;
 using System;
+using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace NeosModLoader
 {
 	internal class ModLoaderConfiguration
 	{
+		private static readonly Lazy<ModLoaderConfiguration> _configuration = new(LoadConfig);
 		private static readonly string CONFIG_FILENAME = "NeosModLoader.config";
 
-		private static ModLoaderConfiguration? _configuration;
+		public bool AdvertiseVersion { get; private set; } = false;
 
-		internal static ModLoaderConfiguration Get()
+		public bool Debug { get; private set; } = false;
+
+		public bool ExposeLateTypes
 		{
-			if (_configuration == null)
-			{
-				// the config file can just sit next to the dll. Simple.
-				string path = Path.Combine(GetAssemblyDirectory(), CONFIG_FILENAME);
-				_configuration = new ModLoaderConfiguration();
+			get => !HideLateTypes;
+			set => HideLateTypes = !value;
+		}
 
+		public bool ExposeModTypes
+		{
+			get => !HideModTypes;
+			set => HideModTypes = !value;
+		}
+
+		public bool HideConflicts
+		{
+			get => !LogConflicts;
+			set => LogConflicts = !value;
+		}
+
+		public bool HideLateTypes { get; private set; } = true;
+
+		public bool HideModTypes { get; private set; } = true;
+
+		public bool HideVisuals { get; private set; } = false;
+
+		public bool LogConflicts { get; private set; } = true;
+
+		public bool NoLibraries { get; private set; } = false;
+
+		public bool NoMods { get; private set; } = false;
+
+		public bool Unsafe { get; private set; } = false;
+
+		internal static ModLoaderConfiguration Get() => _configuration.Value;
+
+		private static string GetAssemblyDirectory()
+		{
+			var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+			var uri = new UriBuilder(codeBase);
+			var path = Uri.UnescapeDataString(uri.Path);
+
+			return Path.GetDirectoryName(path);
+		}
+
+		private static string? GetConfigPath()
+		{
+			if (LaunchArguments.TryGetArgument("Config.Path", out var argument))
+				return argument.Value;
+
+			// the config file can just sit next to the dll. Simple.
+			return Path.Combine(GetAssemblyDirectory(), CONFIG_FILENAME);
+		}
+
+		private static ModLoaderConfiguration LoadConfig()
+		{
+			var path = GetConfigPath();
+			var config = new ModLoaderConfiguration();
+
+			var configOptions = typeof(ModLoaderConfiguration).GetProperties(AccessTools.all).ToArray();
+
+			if (!File.Exists(path))
+			{
+				Logger.MsgInternal($"Using default config - file doesn't exist: {path}");
+			}
+			else
+			{
 				// .NET's ConfigurationManager is some hot trash to the point where I'm just done with it.
 				// Time to reinvent the wheel. This parses simple key=value style properties from a text file.
 				try
@@ -25,49 +89,25 @@ namespace NeosModLoader
 					var lines = File.ReadAllLines(path);
 					foreach (var line in lines)
 					{
-						int splitIdx = line.IndexOf('=');
-						if (splitIdx != -1)
-						{
-							string key = line.Substring(0, splitIdx);
-							string value = line.Substring(splitIdx + 1);
+						var splitIdx = line.IndexOf('=');
+						if (splitIdx == -1)
+							continue;
 
-							if ("unsafe".Equals(key) && "true".Equals(value))
-							{
-								_configuration.Unsafe = true;
-							}
-							else if ("debug".Equals(key) && "true".Equals(value))
-							{
-								_configuration.Debug = true;
-							}
-							else if ("hidevisuals".Equals(key) && "true".Equals(value))
-							{
-								_configuration.HideVisuals = true;
-							}
-							else if ("nomods".Equals(key) && "true".Equals(value))
-							{
-								_configuration.NoMods = true;
-							}
-							else if ("nolibraries".Equals(key) && "true".Equals(value))
-							{
-								_configuration.NoLibraries = true;
-							}
-							else if ("advertiseversion".Equals(key) && "true".Equals(value))
-							{
-								_configuration.AdvertiseVersion = true;
-							}
-							else if ("logconflicts".Equals(key) && "false".Equals(value))
-							{
-								_configuration.LogConflicts = false;
-							}
-							else if ("hidemodtypes".Equals(key) && "false".Equals(value))
-							{
-								_configuration.HideModTypes = false;
-							}
-							else if ("hidelatetypes".Equals(key) && "false".Equals(value))
-							{
-								_configuration.HideLateTypes = false;
-							}
+						string key = line.Substring(0, splitIdx).Trim();
+						string value = line.Substring(splitIdx + 1).Trim();
+
+						var possibleProperty = configOptions.FirstOrDefault(property => property.Name.Equals(key, StringComparison.InvariantCultureIgnoreCase));
+						if (possibleProperty == null)
+						{
+							Logger.WarnInternal($"Unknown key found in config file: {key}");
+							Logger.WarnInternal($"Supported keys: {string.Join(", ", configOptions.Select(property => property.Name))}");
+							continue;
 						}
+
+						var parsedValue = TypeDescriptor.GetConverter(possibleProperty.PropertyType).ConvertFromInvariantString(value);
+						possibleProperty.SetValue(config, parsedValue);
+
+						Logger.MsgInternal($"Loaded value for {possibleProperty.Name} from file: {parsedValue}");
 					}
 				}
 				catch (Exception e)
@@ -86,25 +126,39 @@ namespace NeosModLoader
 					}
 				}
 			}
-			return _configuration;
+
+			try
+			{
+				var boolType = typeof(bool);
+				foreach (var option in configOptions)
+				{
+					if (LaunchArguments.TryGetArgument($"Config.{option.Name}", out var argument))
+					{
+						if (option.PropertyType == boolType)
+						{
+							option.SetValue(config, true);
+							Logger.MsgInternal($"Enabling [{option.Name}] from launch flag");
+						}
+						else if (!argument.IsFlag)
+						{
+							config.SetProperty(option, argument.Value!);
+							Logger.MsgInternal($"Setting [{option.Name}] from launch flag: {argument.Value}");
+						}
+					}
+				}
+			}
+			catch
+			{
+				throw;
+			}
+
+			return config;
 		}
 
-		private static string GetAssemblyDirectory()
+		private void SetProperty(PropertyInfo property, string value)
 		{
-			string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-			UriBuilder uri = new(codeBase);
-			string path = Uri.UnescapeDataString(uri.Path);
-			return Path.GetDirectoryName(path);
+			var parsedValue = TypeDescriptor.GetConverter(property.PropertyType).ConvertFromInvariantString(value);
+			property.SetValue(this, parsedValue);
 		}
-
-		public bool Unsafe { get; private set; } = false;
-		public bool Debug { get; private set; } = false;
-		public bool HideVisuals { get; private set; } = false;
-		public bool NoMods { get; private set; } = false;
-		public bool NoLibraries { get; private set; } = false;
-		public bool AdvertiseVersion { get; private set; } = false;
-		public bool LogConflicts { get; private set; } = true;
-		public bool HideModTypes { get; private set; } = true;
-		public bool HideLateTypes { get; private set; } = true;
 	}
 }

--- a/NeosModLoader/Utility/LaunchArguments.cs
+++ b/NeosModLoader/Utility/LaunchArguments.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static FrooxEngine.FinalIK.IKSolverVR;
+
+namespace NeosModLoader.Utility
+{
+	/// <summary>
+	/// Contains methods to access the command line arguments Neos was launched with.
+	/// </summary>
+	/// Refer to FrooxEngine.Engine.Initialize(...) to gather possible Arguments
+	public static class LaunchArguments
+	{
+		/// <summary>
+		/// Prefix symbol that indicates an argument name: <c>-</c>
+		/// </summary>
+		public const string ArgumentIndicator = "-";
+
+		/// <summary>
+		/// Prefix string that indicated an argument targeted at NML itself or mods loaded by it: <c>-NML.</c><br/>
+		/// This is removed from argument names to get their proper name.
+		/// </summary>
+		public const string NMLArgumentPrefix = ArgumentIndicator + "NML.";
+
+		private static readonly Dictionary<string, Argument> arguments = new();
+		private static readonly string[] possibleNeosArguments = { "config", "LoadAssembly", "GeneratePrecache", "Verbose", "pro", "backgroundworkers", "priorityworkers" };
+		private static readonly string[] possibleNeosFlagArguments = { "GeneratePrecache", "Verbose", "pro" };
+
+		/// <summary>
+		/// Gets all arguments Neos was launched with.
+		/// </summary>
+		public static IEnumerable<Argument> Arguments
+		{
+			get
+			{
+				foreach (var argument in arguments.Values)
+					yield return argument;
+			}
+		}
+
+		/// <summary>
+		/// Gets the names of all flag arguments recognized by Neos.<br/>
+		/// These are forbidden as suffixes of any other arguments.
+		/// </summary>
+		public static IEnumerable<string> PossibleNeosFlagArguments
+		{
+			get
+			{
+				foreach (var flagArgument in possibleNeosFlagArguments)
+					yield return flagArgument;
+			}
+		}
+
+		/// <summary>
+		/// Gets the names of all arguments recognized by Neos.<br/>
+		/// These are forbidden as suffixes of any other arguments.
+		/// </summary>
+		public static IEnumerable<string> PossibleNeosLaunchArguments
+		{
+			get
+			{
+				foreach (var argument in possibleNeosArguments)
+					yield return argument;
+			}
+		}
+
+		static LaunchArguments()
+		{
+			var args = Environment.GetCommandLineArgs();
+
+			var i = 0;
+			while (i < args.Length)
+			{
+				var arg = args[i++];
+
+				var matchedNeosArgument = MatchNeosArgument(arg);
+				if (matchedNeosArgument != null)
+				{
+					if (MatchNeosFlagArgument(matchedNeosArgument) != null)
+						arguments.Add(matchedNeosArgument, new Argument(Target.Neos, arg, matchedNeosArgument));
+					else if (i < args.Length)
+						arguments.Add(matchedNeosArgument, new Argument(Target.Neos, arg, matchedNeosArgument, args[i++]));
+					else
+						Logger.WarnInternal($"Found Neos Launch Argument [{matchedNeosArgument}] without a value");
+
+					continue;
+				}
+
+				string? value = null;
+				// If it's the last argument or followed by another, treat it as a flag
+				if (i < args.Length && !args[i].StartsWith(ArgumentIndicator) && MatchNeosArgument(args[i]) == null)
+					value = args[i];
+
+				if (!arg.StartsWith(NMLArgumentPrefix, StringComparison.InvariantCultureIgnoreCase))
+				{
+					// The value of an unknown argument is not skipped, but added as its own argument in the next iteration as well
+					arguments.Add(arg, new Argument(Target.Unknown, arg, value));
+					continue;
+				}
+
+				// The value of an NML argument gets skipped
+				if (value != null)
+					++i;
+
+				var name = arg.Substring(NMLArgumentPrefix.Length);
+				arguments.Add(name, new Argument(Target.NML, arg, name, value));
+			}
+
+			foreach (var argument in arguments)
+				Logger.MsgInternal($"Parsed {argument}");
+		}
+
+		/// <summary>
+		/// Gets the <see cref="Argument"/> with the given proper name.
+		/// </summary>
+		/// <param name="name">The proper name of the argument.</param>
+		/// <returns>The <see cref="Argument"/> with the given proper name.</returns>
+		/// <exception cref="ArgumentNullException"/>
+		/// <exception cref="KeyNotFoundException"/>
+		public static Argument GetArgument(string name)
+			=> arguments[name];
+
+		/// <summary>
+		/// Checks whether an argument with the given proper name is present.
+		/// </summary>
+		/// <param name="name">The proper name of the argument.</param>
+		/// <returns><c>true</c> if such an argument exists, otherwise <c>false</c>.</returns>
+		public static bool IsPresent(string name)
+			=> arguments.ContainsKey(name);
+
+		/// <summary>
+		/// Tries to find one of the <see cref="PossibleNeosLaunchArguments"/> that is a suffix of the given name.
+		/// </summary>
+		/// <param name="name">The name to check.</param>
+		/// <returns>The matched Neos launch argument or <c>null</c> if there's no match.</returns>
+		public static string? MatchNeosArgument(string name)
+			=> possibleNeosArguments.FirstOrDefault(neosArg => name.EndsWith(neosArg, StringComparison.InvariantCultureIgnoreCase));
+
+		/// <summary>
+		/// Tries to find one of the <see cref="PossibleNeosFlagArguments"/> that is a suffix of the given name.
+		/// </summary>
+		/// <param name="name">The name to check.</param>
+		/// <returns>The matched Neos launch argument flags or <c>null</c> if there's no match.</returns>
+		public static string? MatchNeosFlagArgument(string name)
+			=> possibleNeosFlagArguments.FirstOrDefault(neosArg => name.EndsWith(neosArg, StringComparison.InvariantCultureIgnoreCase));
+
+		/// <summary>
+		/// Tries to get the <see cref="Argument"/> with the given proper name.
+		/// </summary>
+		/// <param name="name">The proper name of the argument.</param>
+		/// <param name="argument">The <see cref="Argument"/> with the given proper name or <c>default(<see cref="Argument"/>)</c> if it's not present.</param>
+		/// <returns><c>true</c> if such an argument exists, otherwise <c>false</c>.</returns>
+		/// <exception cref="ArgumentNullException"/>
+		public static bool TryGetArgument(string name, out Argument argument)
+			=> arguments.TryGetValue(name, out argument);
+
+		/// <summary>
+		/// Data structure for launch arguments.
+		/// </summary>
+		public readonly struct Argument
+		{
+			/// <summary>
+			/// Gets whether the argument is a flag, i.e. whether it doesn't have a value.
+			/// </summary>
+			public bool IsFlag => Value == null;
+
+			/// <summary>
+			/// Gets the proper name of the argument.<br/>
+			/// For <see cref="Target.Neos"/> this is the name Neos looks for,
+			/// while for <see cref="Target.NML"/> this is the name without the <see cref="NMLArgumentPrefix">NML Argument Prefix</see>.
+			/// </summary>
+			public string Name { get; }
+
+			/// <summary>
+			/// Gets the raw name of the argument, as it is on the command line.
+			/// </summary>
+			public string RawName { get; }
+
+			/// <summary>
+			/// Gets the target that the argument is for.
+			/// </summary>
+			public Target Target { get; }
+
+			/// <summary>
+			/// Gets the value associated with the argument. Is <c>null</c> for <see cref="IsFlag">flags</see>.
+			/// </summary>
+			public string? Value { get; }
+
+			internal Argument(Target target, string rawName, string name, string? value = null)
+			{
+				Target = target;
+				RawName = rawName;
+				Name = name;
+				Value = value;
+			}
+
+			internal Argument(Target target, string name, string? value = null)
+				: this(target, name, name, value)
+			{ }
+
+			/// <summary>
+			/// Gets a string representation of this parsed argument.
+			/// </summary>
+			/// <returns>A string representing this parsed argument.</returns>
+			public override string ToString()
+			{
+				return $"{Target} Argument {RawName} ({Name}): {(IsFlag ? "present" : $"\"{Value}\"")}";
+			}
+		}
+
+		/// <summary>
+		/// Different possible targets for command line arguments.
+		/// </summary>
+		public enum Target
+		{
+			/// <summary>
+			/// Not a known target.
+			/// </summary>
+			Unknown,
+
+			/// <summary>
+			/// Targeted at Neos itself.
+			/// </summary>
+			Neos,
+
+			/// <summary>
+			/// Targeted at NML or a mod it loads.
+			/// </summary>
+			NML
+		}
+	}
+}


### PR DESCRIPTION
Implements an expanded upon Version of the feature requested by @art0007i in #75.

Also changed config loading to use reflection to make it more compact, more permissive and easy to add new values.  
Added some inverted properties to allow setting them with flag arguments.