### PR TITLE
Android support with platform-specific helpers

### DIFF
--- a/NeosModLoader/AssemblyLoader.cs
+++ b/NeosModLoader/AssemblyLoader.cs
@@ -1,3 +1,4 @@
+using NeosModLoader.Utility;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,7 +11,7 @@ namespace NeosModLoader
 	{
 		private static string[]? GetAssemblyPathsFromDir(string dirName)
 		{
-			string assembliesDirectory = Path.Combine(Directory.GetCurrentDirectory(), dirName);
+			string assembliesDirectory = Path.Combine(PlatformHelper.MainDirectory, dirName);
 
 			Logger.MsgInternal($"loading assemblies from {dirName}");
 

--- a/NeosModLoader/ModConfiguration.cs
+++ b/NeosModLoader/ModConfiguration.cs
@@ -1,6 +1,7 @@
 using FrooxEngine;
 using HarmonyLib;
 using NeosModLoader.JsonConverters;
+using NeosModLoader.Utility;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -106,7 +107,7 @@ namespace NeosModLoader
 		private readonly ModConfigurationDefinition Definition;
 		internal LoadedNeosMod LoadedNeosMod { get; private set; }
 
-		private static readonly string ConfigDirectory = Path.Combine(Directory.GetCurrentDirectory(), "nml_config");
+		private static readonly string ConfigDirectory = Path.Combine(PlatformHelper.MainDirectory, "nml_config");
 		private static readonly string VERSION_JSON_KEY = "version";
 		private static readonly string VALUES_JSON_KEY = "values";
 

--- a/NeosModLoader/ModLoaderConfiguration.cs
+++ b/NeosModLoader/ModLoaderConfiguration.cs
@@ -1,3 +1,4 @@
+using NeosModLoader.Utility;
 using System;
 using System.IO;
 using System.Reflection;
@@ -15,6 +16,7 @@ namespace NeosModLoader
 			if (_configuration == null)
 			{
 				// the config file can just sit next to the dll. Simple.
+				// ...unless the DLL is embedded. In that case, fallback to MainDirectory.
 				string path = Path.Combine(GetAssemblyDirectory(), CONFIG_FILENAME);
 				_configuration = new ModLoaderConfiguration();
 
@@ -94,6 +96,7 @@ namespace NeosModLoader
 			string codeBase = Assembly.GetExecutingAssembly().CodeBase;
 			UriBuilder uri = new(codeBase);
 			string path = Uri.UnescapeDataString(uri.Path);
+			if (PlatformHelper.IsPathEmbedded(path)) return PlatformHelper.MainDirectory;
 			return Path.GetDirectoryName(path);
 		}
 

--- a/NeosModLoader/Utility/PlatformHelper.cs
+++ b/NeosModLoader/Utility/PlatformHelper.cs
@@ -9,7 +9,8 @@ namespace NeosModLoader.Utility
 		public static readonly string AndroidNeosPath = "/sdcard/ModData/com.Solirax.Neos";
 
 		// Android does not support Directory.GetCurrentDirectory(), so will fall back to the root '/' directory.
-		private static bool UseFallbackPath() => Directory.GetCurrentDirectory().Replace('\\', '/') == "/" && !Directory.Exists("/Neos_Data");
+		public static bool UseFallbackPath() => Directory.GetCurrentDirectory().Replace('\\', '/') == "/" && !Directory.Exists("/Neos_Data");
+		public static bool IsPathEmbedded(string path) => path.StartsWith("/data/app/com.Solirax.Neos");
 
 		public static string MainDirectory
 		{

--- a/NeosModLoader/Utility/PlatformHelper.cs
+++ b/NeosModLoader/Utility/PlatformHelper.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace NeosModLoader.Utility
+{
+	// Provides helper functions for platform-specific operations.
+	// Used for cases such as file handling which can vary between platforms.
+	internal class PlatformHelper
+	{
+		public static readonly string AndroidNeosPath = "/sdcard/ModData/com.Solirax.Neos";
+
+		// Android does not support Directory.GetCurrentDirectory(), so will fall back to the root '/' directory.
+		private static bool UseFallbackPath() => Directory.GetCurrentDirectory().Replace('\\', '/') == "/" && !Directory.Exists("/Neos_Data");
+
+		public static string MainDirectory
+		{
+			get { return UseFallbackPath() ? AndroidNeosPath : Directory.GetCurrentDirectory(); }
+		}
+	}
+}


### PR DESCRIPTION
I've included some very minor changes which allow NML to load and initialize mods on Android platforms.

Most notably, NeosModLoader now targets `/sdcard/ModData/com.Solirax.Neos` in place of the NeosVR installation directory. This is important as `Directory.GetCurrentDirectory()` will return the filesystem's root directory on Android - which is usually unwritable without root permissions. The new directory is also persistent between installs, which helps reduce user friction.

These light changes do not affect the existing Windows/Linux workflow.

*Some things to note:*
- When targeting the NeosVR folder, use `PlatformHelper.MainDirectory` for cross-platform compatibility.
- Paths relative to the executing assembly/current folder/target DLL aren't always what they seem!
- A seperate patching tool will be required to load NML + other plugins. CodeX cannot (directly) load assemblies without the help of a bootstrapper.