### PR TITLE
add fallback for config failure

### DIFF
--- a/NeosModLoader/ModConfiguration.cs
+++ b/NeosModLoader/ModConfiguration.cs
@@ -492,8 +492,10 @@ namespace NeosModLoader
 			catch (Exception e)
 			{
 				// I know not what exceptions the JSON library will throw, but they must be contained
-				mod.AllowSavingConfiguration = false;
-				throw new ModConfigurationException($"Error loading config for {mod.NeosMod.Name}", e);
+				mod.AllowSavingConfiguration = true;
+				var backupPath = configFile + ".bak";
+				Logger.ErrorExternal($"Error loading config for {mod.NeosMod.Name}, creating new config file (old file can be found at {backupPath}). Exception:\n{e}");
+				File.Move(configFile, backupPath);
 			}
 
 			return new ModConfiguration(mod, definition);


### PR DESCRIPTION
idk if this is a good idea but I hate it when my mods don't load because the config files saved incorrectly

(maybe I should stop spamming alt+f4 to quit the game which crashes it during the exit procedure, so that the config files don't corrupt in the first place)